### PR TITLE
Adds possibility to reference a hook by adding heading anchor.

### DIFF
--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -76,7 +76,9 @@ class IndexPage extends React.Component {
                 {hook.repositoryUrl}
               </RepositoryLink>
 
-              <h2>{hook.name}</h2>
+              <a href={`#${hook.name}`}>
+                <h2 id={hook.name}>{hook.name}</h2>
+              </a>
               <Pre>
                 <code>{hook.importStatement}</code>
               </Pre>


### PR DESCRIPTION
This PR adds anchor tags to all hook headings such that one can reference a hook by sharing a URL.

This might come in handy if you decide to host actual hook snippets or gists and may drive more traffic to the site.

Visual changes are as follows, with the headings being anchor tags and underlined when hovered:

![image](https://user-images.githubusercontent.com/959142/47621519-4ab6b580-daf9-11e8-9a73-fec336753322.png)

Let me know if you prefer the original black heading color, or feel free to edit the PR.