### PR TITLE
Add react-selector-hooks

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -262,5 +262,23 @@
     "tags": ["Timing"],
     "repositoryUrl": "https://github.com/kalcifer/react-powerhooks",
     "importStatement": "import { useInterval } from \"react-powerhooks\";"
+  },
+  {
+    "name": "createSelector",
+    "tags": [],
+    "repositoryUrl": "https://github.com/Andarist/react-selector-hooks",
+    "importStatement": "import { createSelector } from \"react-selector-hooks\";"
+  },
+  {
+    "name": "createStateSelector",
+    "tags": [],
+    "repositoryUrl": "https://github.com/Andarist/react-selector-hooks",
+    "importStatement": "import { createStateSelector } from \"react-selector-hooks\";"
+  },
+  {
+    "name": "createStructuredSelector",
+    "tags": [],
+    "repositoryUrl": "https://github.com/Andarist/react-selector-hooks",
+    "importStatement": "import { createStructuredSelector } from \"react-selector-hooks\";"
   }
 ]


### PR DESCRIPTION
Those are actually hook factories, but I think they should count, maybe it would be worth adding a `"usage"` field to JSON entries?