### PR TITLE
adds useMemento

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -550,5 +550,11 @@
     "tags": ["graphQL", "Network", "State Management"],
     "repositoryUrl": "https://github.com/trojanowski/react-apollo-hooks",
     "importStatement": "import { useApolloQuery } from \"react-apollo-hooks\""
+  },
+  {
+    "name": "useMemento",
+    "tags": ["State Management", "Debugging", "Time Travel"],
+    "repositoryUrl": "https://github.com/chasestarr/react-memento",
+    "importStatement": "import { useMemento } from \"react-memento\""
   }
 ]


### PR DESCRIPTION
This is a hook to inspect and step-through state transitions. It can replace a `useState` call in development to debug.

[repo](https://github.com/chasestarr/react-memento)