### PR TITLE
Add useSize

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -664,5 +664,11 @@
     "tags": ["Fetch", "Abortable Fetch"],
     "repositoryUrl": "https://github.com/raghav-grover/use-fetcher",
     "importStatement": "import { useFetcher } from \"use-fetcher\";" 
+  },
+  {
+    "name": "useSize",
+    "tags": ["Browser-API", "Side-effect"],
+    "repositoryUrl": "https://github.com/infodusha/react-hook-size",
+    "importStatement": "import { useSize } from \"react-hook-size\";"
   }
 ]


### PR DESCRIPTION
This hook is not as others in the lib cause it:
* Uses ResizeObserver(or ponyfill)
* Rerenders after first mount(to get size right away)