### PR TITLE
Fix hook wrong links

### DIFF
--- a/site/src/utils.js
+++ b/site/src/utils.js
@@ -61,6 +61,8 @@ function compare(hookA, hookB) {
   }
   if (hookA.name < hookB.name) return -1;
   if (hookA.name > hookB.name) return 1;
+  if (githubName(hookA.repositoryUrl) < githubName(hookB.repositoryUrl)) return -1;
+  if (githubName(hookA.repositoryUrl) > githubName(hookB.repositoryUrl)) return 1;
   return 0;
 }
 


### PR DESCRIPTION
Fixes the site 🔧 

I found some wrong links in current version of https://nikgraf.github.io/react-hooks/ .

For example, `useActive` hooks link are wrong. The href of `kalcifer/react-powerhooks` of `useActive` link is `https://github.com/sandiiarov/use-events`.

I confused why this happens, but finally I found the cause. In short, it's because of inconsistency of hooks sorting between `index.html` and JavaScript sort.

So I added comparing conditions to compare hooks more strictly.
