### PR TITLE
Remove duplicated hook "useDarkMode()"

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -880,12 +880,6 @@
     "importStatement": "import useInterval from '@use-hooks/interval';"
   },
   {
-    "name": "useDarkMode",
-    "tags": [],
-    "repositoryUrl": "https://github.com/donavon/use-dark-mode",
-    "importStatement": "import useDarkMode from 'use-dark-mode';"
-  },
-  {
     "name": "createPersistedState",
     "tags": ["localStorage"],
     "repositoryUrl": "https://github.com/donavon/use-persisted-state",


### PR DESCRIPTION
`useDarkMode()` in repository https://github.com/donavon/use-dark-mode is deplicated in hooks.json.

https://github.com/nikgraf/react-hooks/blob/63a277f713ff3d4190db7ed2b0b60c94db7ae8d9/hooks.json#L87

