### PR TITLE
Added a new hook - "useInView" to the list

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -50,6 +50,13 @@
     "importStatement": "import { useMemo } from 'react';"
   },
   {
+    "name": "useInView",
+    "tags": ["scroll"],
+    "repositoryUrl": "https://github.com/elinadenfina/useinview",
+    "importStatement": "import useInView from 'use-in-view';",
+    "sourceUrl": "https://github.com/elinadenfina/useinview/raw/master/index.js"
+  },
+  {
     "name": "useRef",
     "tags": [
       "React Core"


### PR DESCRIPTION
Not the same hook as the already added hook "useInView". This hook is not using the Intersection Observer, thus requires no polyfills.