### PR TITLE
Fixed import statements duplicating `useWindowSize`

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -292,7 +292,7 @@
       "Layout"
     ],
     "repositoryUrl": "https://github.com/rehooks/document-visibility",
-    "importStatement": "import useWindowSize from '@rehooks/document-visibility';"
+    "importStatement": "import useDocumentVisibility from '@rehooks/document-visibility';"
   },
   {
     "name": "useComponentSize",
@@ -300,7 +300,7 @@
       "Layout"
     ],
     "repositoryUrl": "https://github.com/rehooks/component-size",
-    "importStatement": "import useWindowSize from '@rehooks/component-size';"
+    "importStatement": "import useComponentSize from '@rehooks/component-size';"
   },
   {
     "name": "useDocumentTitle",
@@ -2859,7 +2859,7 @@
       "Time"
     ],
     "repositoryUrl": "https://github.com/imbhargav5/rooks",
-    "importStatement": "import useWindowSize from '@rooks/use-timeout';"
+    "importStatement": "import useTimeout from '@rooks/use-timeout';"
   },
   {
     "name": "useMutationObserver",
@@ -2992,7 +2992,7 @@
       "Size"
     ],
     "repositoryUrl": "https://github.com/contiamo/operational-ui",
-    "importStatement": "import { useGlobal } from '@operational/components';"
+    "importStatement": "import { useWindowSize } from '@operational/components';"
   },
   {
     "name": "useSt8",


### PR DESCRIPTION
Multiple import statements used `useWindowSize` as the import name instead of the actual hook name.

I checked the `@operational/components` repo for the named export, this also seems to be correct, its included in the PR:
```javascript
import { useWindowSize } from '@operational/components';
```

Great work on this collection!