### PR TITLE
Added useMetaTags

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -3331,5 +3331,19 @@
     ],
     "repositoryUrl": "https://github.com/vadzim/use-leaflet#useleafletcenter",
     "importStatement": "import { useLeafletCenter } from 'use-leaflet';"
+  },
+  {
+    "name": "useMetaTags",
+    "tags": [
+      "meta",
+      "metatag"
+    ],
+    "subHooks": [
+      "useRef",
+      "useMemo",
+      "useEffect"
+    ],
+    "repositoryUrl": "https://github.com/lordgiotto/react-metatags-hook",
+    "importStatement": "import useMetaTags from 'react-metatags-hook';"
   }
 ]

--- a/hooks.json
+++ b/hooks.json
@@ -3338,12 +3338,8 @@
       "meta",
       "metatag"
     ],
-    "subHooks": [
-      "useRef",
-      "useMemo",
-      "useEffect"
-    ],
     "repositoryUrl": "https://github.com/lordgiotto/react-metatags-hook",
-    "importStatement": "import useMetaTags from 'react-metatags-hook';"
+    "importStatement": "import useMetaTags from 'react-metatags-hook';",
+    "sourceUrl": "https://github.com/lordgiotto/react-metatags-hook/raw/master/src/index.ts"
   }
 ]


### PR DESCRIPTION
Added [react-metatags-hook](https://github.com/lordgiotto/react-metatags-hook), hook to manage HTML meta tags.
