### PR TITLE
Add a use-ref-scroller hook

### DIFF
--- a/hooks.json
+++ b/hooks.json
@@ -3341,5 +3341,12 @@
     "repositoryUrl": "https://github.com/lordgiotto/react-metatags-hook",
     "importStatement": "import useMetaTags from 'react-metatags-hook';",
     "sourceUrl": "https://github.com/lordgiotto/react-metatags-hook/raw/master/src/index.ts"
+  },
+  {
+    "name": "useRefScroller",
+    "tags": ["scroll"],
+    "repositoryUrl": "https://github.com/dimitar-nikovski/use-ref-scroller",
+    "importStatement": "import useRefScroller from 'use-ref-scroller';",
+    "sourceUrl": "https://github.com/dimitar-nikovski/use-ref-scroller/blob/master/src/useRefScroller.ts"
   }
 ]


### PR DESCRIPTION
A hook for scrolling to a referenced element via calling a handler provided by the hook or on mount. Options are available for offsets, percentages of the window or custom container and the element to be scrolled.