### PR TITLE
Added quick filters based on popular tags

### DIFF
--- a/site/src/pages/index.js
+++ b/site/src/pages/index.js
@@ -14,7 +14,8 @@ import {
   toggleTag,
   toggleSubHook,
   searchQueryToString,
-  getTerms
+  getTerms,
+  sortTags
 } from "../utils";
 
 const device = {
@@ -83,7 +84,7 @@ const SubHook = styled.a`
 
 const FilterInput = styled.input`
   width: 100%;
-  margin-top: 1rem;
+  margin: 1rem 0;
   padding: 0.4rem 0.8rem;
   font-family: "Roboto", sans-serif;
 `;
@@ -99,6 +100,7 @@ const allHooks = sortHooks(unsortedHooks).map((x, i) => {
   x.key = i;
   return x;
 });
+const allTags = sortTags(allHooks);
 
 const IndexPage = () => {
   const [term, setTerm] = useState("");
@@ -109,6 +111,9 @@ const IndexPage = () => {
   const tagsToSearch = getTags(query);
   const hooksToSearch = getSubHooks(query);
   const termsToSearch = getTerms(query);
+
+  const POPULAR_TAG_COUNT = 5;
+	const popularTags = allTags.slice(0, POPULAR_TAG_COUNT);
 
   return (
     <Layout>
@@ -126,6 +131,22 @@ const IndexPage = () => {
         }}
         placeholder="filter by name"
       />
+      {popularTags.map((tag) => (
+        <Tag
+          key={tag.name}
+          href={`#${tag.name}`}
+          onClick={(event) => {
+            event.preventDefault();
+            setTerm(searchQueryToString(toggleTag(query, tag.name)));
+          }}
+        >
+          <Highlighter
+            searchWords={tagsToSearch}
+            autoEscape={true}
+            textToHighlight={`${tag.name} (${tag.count})`}
+          />
+        </Tag>
+      ))}
       <ResultsCount>
         Found {results.length} {results.length === 1 ? "entry" : "entries"}
       </ResultsCount>

--- a/site/src/utils.js
+++ b/site/src/utils.js
@@ -148,3 +148,22 @@ function compare(hookA, hookB) {
 }
 
 export const sortHooks = hooks => hooks.sort(compare);
+
+const compareTags = (tagA, tagB) => tagB.count - tagA.count;
+
+export const sortTags = (hooks) =>
+	hooks.reduce((tags, hook) => {
+		hook.tags.forEach((tag) => {
+			if (tags.map((t) => t.name).includes(tag)) {
+				const index = tags.map((t) => t.name).indexOf(tag);
+				tags[index].count++;
+			} else {
+				tags.push({
+					name: tag,
+					count: 1
+				});
+			}
+		});
+		return tags.sort(compareTags);
+  }, []);
+  


### PR DESCRIPTION
The tag filters are sorted based on the number of hooks under that label and the filters also display this count.

This seems like an enhancement to Issue #4 
<img width="1066" alt="Screenshot 2019-10-07 at 15 18 46" src="https://user-images.githubusercontent.com/8437204/66315367-f2e21a80-e915-11e9-8167-0bb00b2f83e1.png">
.